### PR TITLE
refactor(templates): rename field comment to description

### DIFF
--- a/app/components/templates/templates.html
+++ b/app/components/templates/templates.html
@@ -20,7 +20,7 @@
           <div ng-repeat="tpl in templates" class="container-template hvr-grow" id="template_{{ $index }}" ng-click="selectTemplate($index)">
             <img class="logo" ng-src="{{ tpl.logo }}" />
             <div class="title">{{ tpl.title }}</div>
-            <div class="comment">{{ tpl.comment }}</div>
+            <div class="description">{{ tpl.description }}</div>
           </div>
         </div>
       </rd-widget-body>

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -251,7 +251,7 @@ input[type="radio"] {
   text-align: center;
 }
 
-.container-template .comment {
+.container-template .description {
   text-align: center;
   font-size: 0.8em;
 }


### PR DESCRIPTION
This PR uses the field `description` instead of the field `comment` for the templates.